### PR TITLE
Use constant manager instead of define method 

### DIFF
--- a/src/WordPress/Bootstrap.php
+++ b/src/WordPress/Bootstrap.php
@@ -44,7 +44,8 @@ class Bootstrap
         }
 
         if (app()->runningInConsole() && ! $this->isWordPressInstalled()) {
-            define('WP_INSTALLING', true);
+            Constant::queue('WP_INSTALLING', true);
+            Constant::apply();
         }
         if (! app()->runningInConsole() && $this->isWordPressInstalled()) {
             $this->runWp();


### PR DESCRIPTION
Use Constant object instead of define() method to avoid the 'already defined'.
For example this error occurred during unit testing.