### PR TITLE
Fix Uri trailing slash bug

### DIFF
--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -26,6 +26,14 @@ class Uri
         }
 
         $urlParts = parse_url($url);
+
+        // If the URL cannot be parsed, simply trim the trailing slash and
+        // return the result. This avoids throwing errors when `parse_url`
+        // returns false for malformed URLs.
+        if ($urlParts === false) {
+            return rtrim($url, '/');
+        }
+
         $urlParts['path'] ??= '';
         $urlParts['path'] = rtrim($urlParts['path'], '/');
 

--- a/tests/Unit/Support/UriTest.php
+++ b/tests/Unit/Support/UriTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Pollora\Support\Uri;
+
+describe('Uri helper', function () {
+    it('removes trailing slash from valid urls', function () {
+        $uri = new Uri;
+        expect($uri->removeTrailingSlash('https://example.com/foo/'))->toBe('https://example.com/foo');
+        expect($uri->removeTrailingSlash('/foo/bar/'))->toBe('/foo/bar');
+    });
+
+    it('handles malformed urls gracefully', function () {
+        $uri = new Uri;
+        $malformed = ':///foo/';
+        expect($uri->removeTrailingSlash($malformed))->toBe(':///foo');
+    });
+});


### PR DESCRIPTION
## Summary
- handle malformed URLs in `Uri::removeTrailingSlash`
- add `Uri` unit tests for valid and malformed URLs
- fix styling via Pint

## Testing
- `composer test:lint`
- `composer test` *(fails: rector dry-run found style issues)*
- `composer test:unit` *(fails: code coverage driver not available)*

------
https://chatgpt.com/codex/tasks/task_e_68400bbdae14832f9010308e361cdaef