### PR TITLE
Add detailed PHPDoc and translate comments

### DIFF
--- a/src/Attributes/Action.php
+++ b/src/Attributes/Action.php
@@ -34,7 +34,7 @@ class Action extends Hook
     /**
      * Handle the attribute processing.
      *
-     * @param  object  $serviceLocator  Le service locator pour résoudre les dépendances
+     * @param  object  $serviceLocator  Service locator used to resolve dependencies
      * @param  object  $instance  The instance being processed
      * @param  ReflectionMethod|ReflectionClass  $context  The reflection context
      * @param  object  $attribute  The attribute instance
@@ -45,7 +45,7 @@ class Action extends Hook
         ReflectionMethod|ReflectionClass $context,
         object $attribute,
     ): void {
-        // Récupérer le service Action depuis le service locator
+        // Retrieve the Action service from the locator
         $actionService = $serviceLocator->get(ActionService::class);
         if (! $actionService) {
             return;

--- a/src/Attributes/Filter.php
+++ b/src/Attributes/Filter.php
@@ -34,7 +34,7 @@ class Filter extends Hook
     /**
      * Handle the attribute processing.
      *
-     * @param  object  $serviceLocator  Le service locator pour résoudre les dépendances
+     * @param  object  $serviceLocator  Service locator used to resolve dependencies
      * @param  object  $instance  The instance being processed
      * @param  ReflectionMethod|ReflectionClass  $context  The reflection context
      * @param  object  $attribute  The attribute instance
@@ -45,7 +45,7 @@ class Filter extends Hook
         ReflectionMethod|ReflectionClass $context,
         object $attribute
     ): void {
-        // Récupérer le service Filter depuis le service locator
+        // Retrieve the Filter service from the locator
         $filterService = $serviceLocator->get(FilterService::class);
         if (! $filterService) {
             return;

--- a/src/Attributes/Schedule.php
+++ b/src/Attributes/Schedule.php
@@ -51,19 +51,19 @@ class Schedule implements HandlesAttributes
     /**
      * Registers the scheduled event with WordPress.
      *
-     * @param  mixed  $container  Le service locator pour résoudre les dépendances.
+     * @param  mixed  $container  Service locator used to resolve dependencies.
      * @param  Attributable  $instance  Instance of the class containing the method to schedule.
      * @param  ReflectionClass|ReflectionMethod  $context  The reflection context.
      * @param  object  $attribute  The attribute instance.
      */
     public function handle($container, Attributable $instance, ReflectionClass|ReflectionMethod $context, object $attribute): void
     {
-        // Vérifier que le contexte est une méthode
+        // Ensure the context is a method
         if (! ($context instanceof ReflectionMethod)) {
             return;
         }
 
-        // Récupérer le service Action depuis le service locator - handle both modern and legacy containers
+        // Retrieve the Action service from the locator - handle both modern and legacy containers
         if (method_exists($container, 'resolve')) {
             $actionService = $container->resolve(ActionService::class);
         } else {
@@ -74,7 +74,7 @@ class Schedule implements HandlesAttributes
             return;
         }
 
-        // Utiliser les propriétés de l'attribut ou de l'instance
+        // Use the attribute properties or fall back to instance values
         $hookName = $attribute->hook ?? $this->generateHookName($context);
         $recurrence = $attribute->recurrence ?? $this->recurrence;
         $args = $attribute->args ?? $this->args;

--- a/src/Attributes/WpRestRoute.php
+++ b/src/Attributes/WpRestRoute.php
@@ -31,8 +31,8 @@ class WpRestRoute implements HandlesAttributes
     /**
      * Handle the attribute processing.
      *
-     * @param  object  $serviceLocator  Le service locator pour résoudre les dépendances
-     * @param  object  $instance  The instance to which the attribute applies.
+     * @param  object  $serviceLocator  Service locator used to resolve dependencies
+     * @param  object  $instance  The instance to which the attribute applies
      * @param  ReflectionClass|ReflectionMethod  $context  The reflection context.
      * @param  object  $attribute  The attribute instance containing provided arguments.
      */

--- a/src/Attributes/WpRestRoute/Method.php
+++ b/src/Attributes/WpRestRoute/Method.php
@@ -68,7 +68,7 @@ class Method implements HandlesAttributes
     /**
      * Handles the registration of the REST route for the method.
      *
-     * @param  object  $serviceLocator  Le service locator pour résoudre les dépendances
+     * @param  object  $serviceLocator  Service locator used to resolve dependencies
      * @param  Attributable  $instance  The class instance
      * @param  ReflectionMethod|ReflectionClass  $context  The reflection context
      * @param  object  $attribute  The attribute instance

--- a/src/Container/Domain/ServiceLocator.php
+++ b/src/Container/Domain/ServiceLocator.php
@@ -7,16 +7,17 @@ namespace Pollora\Container\Domain;
 /**
  * Interface ServiceLocator
  *
- * Définit un contrat pour résoudre des services à partir d'un conteneur.
- * Cette interface fait partie du domaine et est indépendante de l'implémentation spécifique.
+ * Defines a contract for resolving services from a container.
+ * This interface is part of the domain layer and is independent of any
+ * specific implementation.
  */
 interface ServiceLocator
 {
     /**
-     * Résout un service à partir de sa classe.
+     * Resolve a service by its class name.
      *
-     * @param  string  $serviceClass  La classe du service à résoudre
-     * @return mixed|null Le service résolu ou null s'il n'est pas trouvé
+     * @param  string  $serviceClass  The class of the service to resolve
+     * @return mixed|null The resolved service or null if not found
      */
     public function resolve(string $serviceClass);
 }

--- a/src/Container/Infrastructure/ContainerServiceLocator.php
+++ b/src/Container/Infrastructure/ContainerServiceLocator.php
@@ -9,20 +9,23 @@ use Pollora\Container\Domain\ServiceLocator;
 /**
  * Class ContainerServiceLocator
  *
- * Implémentation du service locator qui utilise un conteneur d'injection de dépendances.
- * Cette classe fait partie de l'infrastructure et s'occupe de la résolution concrète des services.
+ * Service locator implementation that relies on a dependency injection
+ * container. This infrastructure class is responsible for resolving
+ * services from the given container.
  */
 class ContainerServiceLocator implements ServiceLocator
 {
     /**
-     * @var mixed Le conteneur d'injection de dépendances
+     * The dependency injection container instance.
+     *
+     * @var mixed
      */
     private $container;
 
     /**
-     * ContainerServiceLocator constructor.
+     * Create a new service locator instance.
      *
-     * @param  mixed  $container  Le conteneur d'injection de dépendances
+     * @param  mixed  $container  The dependency injection container
      */
     public function __construct($container)
     {
@@ -30,7 +33,10 @@ class ContainerServiceLocator implements ServiceLocator
     }
 
     /**
-     * {@inheritdoc}
+     * Resolve a service from the container.
+     *
+     * @param  string  $serviceClass  Fully qualified class name of the service
+     * @return mixed|null The resolved service instance or null when not found
      */
     public function resolve(string $serviceClass)
     {
@@ -38,12 +44,12 @@ class ContainerServiceLocator implements ServiceLocator
             return null;
         }
 
-        // Gestion des conteneurs de type tableau associatif
+        // Handle associative array style containers
         if (is_array($this->container) && isset($this->container[$serviceClass])) {
             return $this->container[$serviceClass];
         }
 
-        // Gestion des conteneurs de type PSR-11 ou similaires
+        // Handle PSR-11 style containers or similar
         if (is_object($this->container) && method_exists($this->container, 'get')) {
             try {
                 return $this->container->get($serviceClass);

--- a/src/Http/Controllers/FrontendController.php
+++ b/src/Http/Controllers/FrontendController.php
@@ -13,10 +13,12 @@ class FrontendController extends Controller
 {
     /**
      * Create a new FrontendController instance.
+     *
+     * @param  TemplateHierarchy  $templateHierarchy  Template hierarchy resolver
      */
     public function __construct(
         /**
-         * The template hierarchy instance
+         * Template hierarchy resolver
          */
         private readonly TemplateHierarchy $templateHierarchy
     ) {}
@@ -24,25 +26,27 @@ class FrontendController extends Controller
     /**
      * Handle the automatic view assignment for WordPress templates.
      *
-     * This method will automatically determine the appropriate view
-     * based on WordPress conditional tags and template hierarchy.
+     * This method automatically determines the appropriate view
+     * based on WordPress conditional tags and the template hierarchy.
+     *
+     * @return View|null The resolved view instance or null on failure
      */
     public function handle(): ?View
     {
         global $wp_query;
 
-        // Obtenir la hiérarchie des templates pour la requête actuelle
-        // Utiliser directement la méthode qui renvoie les chemins de template
+        // Get the template hierarchy for the current request
+        // Use the method that directly returns the template paths
         $views = $this->templateHierarchy->getAllTemplatePaths();
 
-        // Vérifier si des vues existent pour chaque template dans la hiérarchie
+        // Check if a view exists for each template in the hierarchy
         foreach ($views as $view) {
             if (ViewFacade::exists($view)) {
                 return view($view);
             }
         }
 
-        // Si aucun template n'est trouvé, retourner une vue 404
+        // If no template is found, return a 404 view
         $wp_query->set_404();
         abort(404);
     }

--- a/src/PostType/Infrastructure/Adapters/WordPressPostTypeRegistry.php
+++ b/src/PostType/Infrastructure/Adapters/WordPressPostTypeRegistry.php
@@ -72,7 +72,7 @@ class WordPressPostTypeRegistry implements PostTypeRegistryInterface
      */
     private function preparePostTypeArgs(object $postType): array
     {
-        // Utilise les méthodes si elles existent
+        // Use the methods if they exist
         $args = method_exists($postType, 'getArgs') ? $postType->getArgs() : [];
 
         // Add labels if not explicitly provided

--- a/src/Route/Infrastructure/Adapters/Route.php
+++ b/src/Route/Infrastructure/Adapters/Route.php
@@ -392,13 +392,13 @@ class Route extends IlluminateRoute
      */
     public function controllerDispatcher()
     {
-        // Essayer de récupérer le container s'il n'est pas défini
+        // Attempt to retrieve the container if it has not been set
         if (! $this->container) {
             if (class_exists('Illuminate\Container\Container')) {
                 $this->container = \Illuminate\Container\Container::getInstance();
             }
 
-            // Si toujours pas de container, lancer une exception
+            // If a container still cannot be found, throw an exception
             if (! $this->container) {
                 throw new \RuntimeException('Container is not set on route.');
             }

--- a/src/Support/WpGlobals.php
+++ b/src/Support/WpGlobals.php
@@ -12,7 +12,9 @@ namespace Pollora\Support;
 class WpGlobals
 {
     /**
-     * List of essential WordPress globals that are commonly needed
+     * List of essential WordPress globals that are commonly needed.
+     *
+     * @var array<int, string>
      */
     private static array $essentialGlobals = [
         'current_user',
@@ -37,19 +39,19 @@ class WpGlobals
      */
     public static function wrap(callable $callback, ?array $globals = null): callable
     {
-        // Si $globals est null, utiliser la liste par défaut
+        // If $globals is null, use the default list
         $globalKeys = $globals ?? self::$essentialGlobals;
 
-        // Capturer les variables globales
+        // Capture the global variables
         $capturedGlobals = array_intersect_key($GLOBALS, array_flip($globalKeys));
 
         return static function (...$args) use ($callback, $capturedGlobals) {
-            // Réinjecter les globales dans le contexte
+            // Reinject the globals into the context
             foreach ($capturedGlobals as $key => $value) {
                 $GLOBALS[$key] = $value;
             }
 
-            // Exécuter le callback
+            // Execute the callback
             return $callback(...$args);
         };
     }

--- a/src/Taxonomy/Infrastructure/Adapters/WordPressTaxonomyRegistry.php
+++ b/src/Taxonomy/Infrastructure/Adapters/WordPressTaxonomyRegistry.php
@@ -73,7 +73,7 @@ class WordPressTaxonomyRegistry implements TaxonomyRegistryInterface
      */
     private function prepareTaxonomyArgs(object $taxonomy): array
     {
-        // Utilise les méthodes si elles existent
+        // Use the methods if they exist
         $args = method_exists($taxonomy, 'getArgs') ? $taxonomy->getArgs() : [];
 
         // Add labels if not explicitly provided

--- a/src/Theme/Infrastructure/Providers/ThemeServiceProvider.php
+++ b/src/Theme/Infrastructure/Providers/ThemeServiceProvider.php
@@ -299,7 +299,7 @@ class ThemeServiceProvider extends ServiceProvider
             });
         }
 
-        // Fallback si l'instance retournée n'est pas une Collection Laravel
+        // Fallback if the returned instance is not a Laravel Collection
         return collect(['Directives'])
             ->flatMap(function ($directive) {
                 if (file_exists($directives = __DIR__.'/'.$directive.'.php')) {

--- a/src/Theme/Infrastructure/Services/Support.php
+++ b/src/Theme/Infrastructure/Services/Support.php
@@ -17,20 +17,38 @@ use Psr\Container\ContainerInterface;
  */
 class Support implements ThemeComponent
 {
+    /**
+     * WordPress action service used to register callbacks.
+     *
+     * @var Action
+     */
     protected Action $action;
 
+    /**
+     * Create a new Support service instance.
+     *
+     * @param  ContainerInterface  $app     The service container
+     * @param  ConfigRepositoryInterface  $config  The configuration repository
+     */
     public function __construct(protected ContainerInterface $app, protected ConfigRepositoryInterface $config)
     {
         $this->action = $this->app->get(Action::class);
     }
 
+    /**
+     * Register the theme support callbacks.
+     *
+     * @return void
+     */
     public function register(): void
     {
         $this->action->add('after_setup_theme', [$this, 'addThemeSupport'], 1);
     }
 
     /**
-     * Register all of the site's theme support.
+     * Register all of the site's theme support options.
+     *
+     * @return void
      */
     public function addThemeSupport(): void
     {

--- a/src/Theme/UI/Console/BaseThemeCommand.php
+++ b/src/Theme/UI/Console/BaseThemeCommand.php
@@ -9,35 +9,80 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Pollora\Theme\Domain\Models\ThemeMetadata;
 
+/**
+ * Base command class used by theme related CLI commands.
+ *
+ * Provides common helper methods for working with themes on the
+ * filesystem.
+ */
 abstract class BaseThemeCommand extends Command
 {
+    /**
+     * Cached ThemeMetadata instance for the current command run.
+     *
+     * @var ThemeMetadata
+     */
     protected ThemeMetadata $themeInfo;
 
+    /**
+     * Create a new command instance.
+     *
+     * @param  Repository  $config  The configuration repository
+     * @param  Filesystem  $files   Filesystem instance used for file operations
+     */
     public function __construct(protected Repository $config, protected Filesystem $files)
     {
         parent::__construct();
     }
 
+    /**
+     * Determine if the theme directory already exists.
+     *
+     * @return bool True when the directory exists
+     */
     protected function directoryExists(): bool
     {
         return $this->files->isDirectory($this->getTheme()->getBasePath());
     }
 
+    /**
+     * Get the ThemeMetadata instance for the theme being handled.
+     *
+     * @return ThemeMetadata The theme metadata object
+     */
     protected function getTheme(): ThemeMetadata
     {
         return $this->themeInfo ??= $this->makeTheme($this->argument('name'));
     }
 
+    /**
+     * Create a ThemeMetadata object for the given name.
+     *
+     * @param  string  $name  Name of the theme
+     * @return ThemeMetadata The created theme metadata
+     */
     protected function makeTheme(string $name): ThemeMetadata
     {
         return new ThemeMetadata($name, $this->getThemesPath());
     }
 
+    /**
+     * Get the base directory where themes are stored.
+     *
+     * @return string The absolute path to the themes directory
+     */
     protected function getThemesPath(): string
     {
         return $this->config->get('theme.directory', base_path('themes'));
     }
 
+    /**
+     * Create a file within the theme directory.
+     *
+     * @param  string  $path     Path relative to the theme base directory
+     * @param  string  $content  Optional file contents
+     * @return void
+     */
     protected function makeFile(string $path, string $content = ''): void
     {
         $fullPath = $this->getTheme()->getBasePath().'/'.$path;
@@ -45,6 +90,13 @@ abstract class BaseThemeCommand extends Command
         $this->files->put($fullPath, $content);
     }
 
+    /**
+     * Generate file contents from a stub template.
+     *
+     * @param  string  $templateName  The stub template filename
+     * @param  array<string, string>  $replacements  Key-value replacements within the stub
+     * @return string The populated template content
+     */
     protected function fromTemplate(string $templateName, array $replacements = []): string
     {
         $templatePath = $this->getTemplatePath($templateName);
@@ -57,9 +109,15 @@ abstract class BaseThemeCommand extends Command
         );
     }
 
+    /**
+     * Resolve the path to a stub template.
+     *
+     * @param  string  $templateName  Template file name
+     * @return string Absolute path to the stub file
+     */
     protected function getTemplatePath(string $templateName): string
     {
-        // Implémentation par défaut
+        // Default implementation
         return realpath(__DIR__.'/../../stubs/'.$templateName);
     }
 }

--- a/src/Theme/UI/Console/MakeThemeCommand.php
+++ b/src/Theme/UI/Console/MakeThemeCommand.php
@@ -301,17 +301,17 @@ class MakeThemeCommand extends BaseThemeCommand implements PromptsForMissingInpu
             $content = File::get($sourcePath);
             $replacements = $this->getReplacements();
 
-            // Appliquer les remplacements
+            // Apply placeholder replacements
             $content = str_replace(
                 array_keys($replacements),
                 array_values($replacements),
                 $content
             );
 
-            // Écrire le contenu modifié dans le fichier de destination
+            // Write the modified content to the destination file
             File::put($destinationPath, $content);
         } else {
-            // Copier simplement les fichiers non textuels sans modification
+            // Simply copy non-text files without modification
             File::copy($sourcePath, $destinationPath);
         }
     }

--- a/src/Theme/UI/Console/RemoveThemeCommand.php
+++ b/src/Theme/UI/Console/RemoveThemeCommand.php
@@ -7,17 +7,31 @@ namespace Pollora\Theme\UI\Console;
 use Illuminate\Config\Repository;
 use Illuminate\Filesystem\Filesystem;
 
+/**
+ * Console command used to remove an existing theme from the filesystem.
+ */
 class RemoveThemeCommand extends BaseThemeCommand
 {
     protected $signature = 'pollora:delete-theme {name : Name of the theme to remove}';
 
     protected $description = 'Remove an existing theme';
 
+    /**
+     * Create a new command instance.
+     *
+     * @param  Repository  $config  The configuration repository
+     * @param  Filesystem  $files   Filesystem instance used for file operations
+     */
     public function __construct(Repository $config, Filesystem $files)
     {
         parent::__construct($config, $files);
     }
 
+    /**
+     * Execute the command.
+     *
+     * @return int Command exit code
+     */
     public function handle(): int
     {
         $themeName = $this->argument('name');
@@ -40,6 +54,11 @@ class RemoveThemeCommand extends BaseThemeCommand
         return self::SUCCESS;
     }
 
+    /**
+     * Delete the theme directory and its assets.
+     *
+     * @return void
+     */
     protected function removeTheme(): void
     {
         $themePath = $this->getTheme()->getBasePath();
@@ -51,6 +70,11 @@ class RemoveThemeCommand extends BaseThemeCommand
         }
     }
 
+    /**
+     * Get the public path where theme assets are stored.
+     *
+     * @return string The absolute path to the assets directory
+     */
     protected function getAssetsPath(): string
     {
         $assetsPath = $this->config->get('theme.assets_path', 'themes');

--- a/src/Theme/stubs/common/vite.config.js
+++ b/src/Theme/stubs/common/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import laravel, { refreshPaths } from 'laravel-vite-plugin';
 import path from 'path';
 
-// Détection de l'environnement
+// Environment detection
 const isDocker = process.env.IS_DOCKER || process.env.DOCKER_ENV || process.env.DDEV_PRIMARY_URL;
 const port = 5173;
 const publicDirectory = "../../public";


### PR DESCRIPTION
## Summary
- document service locator interface in English
- add parameter and return docs for theme console commands and services
- translate remaining French comments in attributes and route adapter
- document WordPress globals property type

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842769848d4832f83db2f917c5f50ff