### PR TITLE
Add missing PHPDoc comments

### DIFF
--- a/src/Route/Infrastructure/Middleware/WordPressBodyClass.php
+++ b/src/Route/Infrastructure/Middleware/WordPressBodyClass.php
@@ -25,6 +25,10 @@ class WordPressBodyClass
      * Handle the incoming request.
      *
      * Adds a filter to modify the WordPress body classes based on the current route.
+     *
+     * @param  Request  $request  Incoming HTTP request
+     * @param  Closure  $next     Next middleware handler
+     * @return mixed             Response from subsequent middleware
      */
     public function handle(Request $request, Closure $next): mixed
     {
@@ -39,6 +43,9 @@ class WordPressBodyClass
 
     /**
      * Get the callback for modifying body classes.
+     *
+     * @param  Route  $route  The current route instance
+     * @return Closure       Callback that filters the body class array
      */
     private function getBodyClassCallback(Route $route): Closure
     {
@@ -64,7 +71,8 @@ class WordPressBodyClass
     /**
      * Extract route tokens for body classes.
      *
-     * @return array<string>
+     * @param  Route  $route  Route instance to inspect
+     * @return array<string> Array of tokens for body class generation
      */
     private function getRouteTokens(Route $route): array
     {
@@ -89,6 +97,10 @@ class WordPressBodyClass
 
     /**
      * Handle variable tokens in the route.
+     *
+     * @param  array  $token  Token definition from the compiled route
+     * @param  Route  $route  Current route instance
+     * @return string|false  Sanitized token or false when not applicable
      */
     private function handleVariableToken(array $token, Route $route): string|false
     {
@@ -105,6 +117,9 @@ class WordPressBodyClass
 
     /**
      * Sanitize a string for use as a CSS class.
+     *
+     * @param  string  $text  Text to sanitize
+     * @return string        Sanitized CSS class value
      */
     private function sanitizeClass(string $text): string
     {

--- a/src/Route/Infrastructure/Middleware/WordPressHeaders.php
+++ b/src/Route/Infrastructure/Middleware/WordPressHeaders.php
@@ -33,6 +33,10 @@ class WordPressHeaders
      * - Adding framework identification
      * - Cleaning up WordPress headers for non-authenticated requests
      * - Setting appropriate cache control directives
+     *
+     * @param  Request  $request  Incoming HTTP request
+     * @param  Closure  $next     Next middleware handler
+     * @return SymfonyResponse   Modified response instance
      */
     public function handle(Request $request, Closure $next): SymfonyResponse
     {
@@ -59,6 +63,8 @@ class WordPressHeaders
 
     /**
      * Add the framework identification header.
+     *
+     * @param  SymfonyResponse  $response  Response being modified
      */
     private function addFrameworkHeader(SymfonyResponse $response): void
     {
@@ -67,6 +73,9 @@ class WordPressHeaders
 
     /**
      * Determine if WordPress headers should be cleaned up.
+     *
+     * @param  Request  $request  Incoming request instance
+     * @return bool              True when headers should be removed
      */
     private function shouldCleanupHeaders(Request $request): bool
     {
@@ -81,6 +90,8 @@ class WordPressHeaders
 
     /**
      * Remove WordPress-specific headers from the response.
+     *
+     * @param  SymfonyResponse  $response  Response to clean up
      */
     private function removeWordPressHeaders(SymfonyResponse $response): void
     {
@@ -91,6 +102,8 @@ class WordPressHeaders
 
     /**
      * Determine if public cache headers should be set.
+     *
+     * @return bool True when public caching is allowed
      */
     private function shouldSetPublicCache(): bool
     {
@@ -99,6 +112,9 @@ class WordPressHeaders
 
     /**
      * Check if a WordPress function is available.
+     *
+     * @param  string  $function  Function name to check
+     * @return bool              True if the function exists
      */
     private function isWordPressFunctionAvailable(string $function): bool
     {

--- a/src/Route/Infrastructure/Middleware/WordPressShutdown.php
+++ b/src/Route/Infrastructure/Middleware/WordPressShutdown.php
@@ -19,6 +19,10 @@ class WordPressShutdown
      * Handle the incoming request.
      *
      * Ensures WordPress shutdown hooks are executed after the response.
+     *
+     * @param  Request  $request  Incoming HTTP request
+     * @param  Closure  $next     Next middleware handler
+     * @return mixed             Response from subsequent middleware
      */
     public function handle(Request $request, Closure $next): mixed
     {

--- a/src/Route/Infrastructure/Services/ExtendedRouter.php
+++ b/src/Route/Infrastructure/Services/ExtendedRouter.php
@@ -108,7 +108,10 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Check if action is valid for WordPress binding.
+     * Check if an action array is valid for WordPress parameter binding.
+     *
+     * @param  array  $action  Route action definition
+     * @return bool            True when a callable "uses" entry exists
      */
     private function isValidActionForBinding(array $action): bool
     {
@@ -116,7 +119,10 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Bind WordPress parameters to route based on reflection.
+     * Bind WordPress parameters to a route based on reflection data.
+     *
+     * @param  Route                        $route       Route instance to bind
+     * @param  \ReflectionFunctionAbstract  $reflection  Callable reflection for parameter inspection
      */
     private function bindWordPressParametersToRoute(Route $route, \ReflectionFunctionAbstract $reflection): void
     {
@@ -137,7 +143,10 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Get reflection from a callable with improved error handling.
+     * Get reflection information from a callable with error handling.
+     *
+     * @param  mixed  $callable  The callable to reflect
+     * @return \ReflectionFunctionAbstract|null Reflection object or null on failure
      */
     protected function getCallableReflection($callable): ?\ReflectionFunctionAbstract
     {
@@ -157,7 +166,10 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Get method reflection from string format (Class@method).
+     * Get a method reflection from string format (Class@method).
+     *
+     * @param  string  $callable  Callable string in Class@method form
+     * @return \ReflectionMethod  Reflection of the specified method
      */
     private function getMethodReflection(string $callable): \ReflectionMethod
     {
@@ -167,7 +179,9 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Create default condition manager if none provided.
+     * Create the default WordPress condition manager when none is provided.
+     *
+     * @return WordPressConditionManagerInterface Condition manager instance
      */
     private function createDefaultConditionManager(): WordPressConditionManagerInterface
     {
@@ -175,7 +189,11 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Log error with context if logger is available.
+     * Log an error with context if a logger is available.
+     *
+     * @param  string     $message    Error message
+     * @param  \Throwable $exception  Exception instance
+     * @param  array      $context    Additional logging context
      */
     private function logError(string $message, \Throwable $exception, array $context = []): void
     {
@@ -188,7 +206,10 @@ class ExtendedRouter extends IlluminateRouter
     }
 
     /**
-     * Create a safe resolver that handles exceptions.
+     * Wrap a resolver callable to safely catch exceptions.
+     *
+     * @param  callable  $resolver  Resolver to wrap
+     * @return \Closure  Safe wrapper closure
      */
     private function createSafeResolver(callable $resolver): \Closure
     {

--- a/src/Route/Infrastructure/Services/Resolvers/WordPressTypeResolver.php
+++ b/src/Route/Infrastructure/Services/Resolvers/WordPressTypeResolver.php
@@ -16,6 +16,9 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
      */
     private array $resolvers;
 
+    /**
+     * Create a new resolver instance and register default resolvers.
+     */
     public function __construct()
     {
         $this->resolvers = [
@@ -27,6 +30,12 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
         ];
     }
 
+    /**
+     * Resolve a WordPress type by name.
+     *
+     * @param  string  $typeName  Fully qualified WP_* class name
+     * @return mixed|null         The resolved object or null if unavailable
+     */
     public function resolve(string $typeName): mixed
     {
         if (! isset($this->resolvers[$typeName])) {
@@ -36,6 +45,11 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
         return call_user_func($this->resolvers[$typeName]);
     }
 
+    /**
+     * Resolve the current WP_Post object if available.
+     *
+     * @return \WP_Post|null
+     */
     public function resolvePost(): ?\WP_Post
     {
         global $post;
@@ -56,6 +70,11 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
         return null;
     }
 
+    /**
+     * Resolve the current WP_Term object if available.
+     *
+     * @return \WP_Term|null
+     */
     public function resolveTerm(): ?\WP_Term
     {
         if (! function_exists('get_queried_object')) {
@@ -67,6 +86,11 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
         return $queried instanceof \WP_Term ? $queried : null;
     }
 
+    /**
+     * Resolve the current WP_User object if available.
+     *
+     * @return \WP_User|null
+     */
     public function resolveUser(): ?\WP_User
     {
         if (function_exists('get_queried_object')) {
@@ -87,6 +111,11 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
         return null;
     }
 
+    /**
+     * Resolve the global WP_Query instance.
+     *
+     * @return \WP_Query|null
+     */
     public function resolveQuery(): ?\WP_Query
     {
         global $wp_query;
@@ -94,6 +123,11 @@ class WordPressTypeResolver implements WordPressTypeResolverInterface
         return $wp_query instanceof \WP_Query ? $wp_query : null;
     }
 
+    /**
+     * Resolve the global WP instance.
+     *
+     * @return \WP|null
+     */
     public function resolveWP(): ?\WP
     {
         global $wp;

--- a/src/Route/Infrastructure/Services/WordPressConditionManager.php
+++ b/src/Route/Infrastructure/Services/WordPressConditionManager.php
@@ -12,17 +12,38 @@ use Pollora\Route\Infrastructure\Services\Contracts\WordPressConditionManagerInt
  */
 class WordPressConditionManager implements WordPressConditionManagerInterface
 {
+    /**
+     * Registered condition aliases mapped to their WordPress functions.
+     *
+     * @var array<string, string>
+     */
     private array $conditions = [];
 
+    /**
+     * Indicates whether conditions have been loaded from all sources.
+     */
     private bool $loaded = false;
 
+    /**
+     * Laravel container instance for optional config access.
+     */
     private ?Container $container;
 
+    /**
+     * Create a new condition manager instance.
+     *
+     * @param  Container|null  $container  Optional service container
+     */
     public function __construct(?Container $container = null)
     {
         $this->container = $container;
     }
 
+    /**
+     * Get all registered conditions.
+     *
+     * @return array<string, string> List of condition aliases and functions
+     */
     public function getConditions(): array
     {
         $this->ensureConditionsLoaded();
@@ -30,6 +51,12 @@ class WordPressConditionManager implements WordPressConditionManagerInterface
         return $this->conditions;
     }
 
+    /**
+     * Resolve a condition alias to its WordPress function.
+     *
+     * @param  string  $condition  Condition alias
+     * @return string  Resolved WordPress function name
+     */
     public function resolveCondition(string $condition): string
     {
         $this->ensureConditionsLoaded();
@@ -37,6 +64,12 @@ class WordPressConditionManager implements WordPressConditionManagerInterface
         return $this->conditions[$condition] ?? $condition;
     }
 
+    /**
+     * Add a new condition alias mapping.
+     *
+     * @param  string  $alias     Alias used in routing configuration
+     * @param  string  $function  WordPress conditional function name
+     */
     public function addCondition(string $alias, string $function): void
     {
         $this->ensureConditionsLoaded();
@@ -45,6 +78,9 @@ class WordPressConditionManager implements WordPressConditionManagerInterface
 
     /**
      * Load conditions from multiple sources.
+     */
+    /**
+     * Ensure conditions are loaded from defaults and configuration.
      */
     private function ensureConditionsLoaded(): void
     {
@@ -60,6 +96,9 @@ class WordPressConditionManager implements WordPressConditionManagerInterface
 
     /**
      * Load default WordPress conditions.
+     */
+    /**
+     * Load the built-in set of WordPress conditions.
      */
     private function loadDefaultConditions(): void
     {
@@ -95,6 +134,9 @@ class WordPressConditionManager implements WordPressConditionManagerInterface
 
     /**
      * Load conditions from Laravel config.
+     */
+    /**
+     * Load additional conditions from configuration if available.
      */
     private function loadConfigConditions(): void
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,6 +6,16 @@ use Illuminate\Support\Str;
 use Pollora\Support\RecursiveMenuIterator;
 
 if (! function_exists('wp_mail')) {
+    /**
+     * Send an email using the configured mailer.
+     *
+     * @param  string|array  $to          Recipient email address or array of addresses
+     * @param  string        $subject     Email subject line
+     * @param  string        $message     Email body content
+     * @param  string|array  $headers     Optional headers
+     * @param  array         $attachments List of file paths to attach
+     * @return bool          True on success, false otherwise
+     */
     function wp_mail($to, $subject, $message, $headers = '', $attachments = []): bool
     {
         $result = app('wp.mail')->send($to, $subject, $message, $headers, $attachments);
@@ -25,6 +35,11 @@ if (! function_exists('mysqli_report')) {
 }
 
 if (! function_exists('is_secured')) {
+    /**
+     * Determine if the application URL is served over HTTPS.
+     *
+     * @return bool True when the configured app URL uses the HTTPS scheme
+     */
     function is_secured(): bool
     {
         return str_contains((string) config('app.url'), 'https://');


### PR DESCRIPTION
## Summary
- document `wp_mail` and `is_secured` helpers
- add missing PHPDoc blocks in `WordPressConditionManager`
- improve docs for `WordPressTypeResolver`
- expand middleware docs for body class, headers and shutdown handling
- document private helpers in `ExtendedRouter`