### PR TITLE
Feature/seo http status

### DIFF
--- a/src/Route/UI/Http/Controllers/FrontendController.php
+++ b/src/Route/UI/Http/Controllers/FrontendController.php
@@ -43,7 +43,7 @@ class FrontendController
         $viewName = $this->templateFinder->getViewNameFromPath($templatePath);
 
         if ($viewName && View::exists($viewName)) {
-            return response(View::make($viewName), is_404() ? Response::HTTP_NOT_FOUND : Response::HTTP_ACCEPTED);
+            return response(View::make($viewName), is_404() ? Response::HTTP_NOT_FOUND : Response::HTTP_OK);
         }
 
         if (file_exists($templatePath)) {


### PR DESCRIPTION
Our SEO team reported that the HTTP status of the pages was 202 instead of 200. This is due to the use of the HTTP_ACCEPTED constant instead of HTTP_OK