### PR TITLE
feat: add update notifications for new Pollora versions

### DIFF
--- a/src/Providers/PolloraServiceProvider.php
+++ b/src/Providers/PolloraServiceProvider.php
@@ -38,6 +38,7 @@ use Pollora\Taxonomy\Infrastructure\Providers\TaxonomyServiceProvider;
 use Pollora\Theme\Infrastructure\Providers\ThemeServiceProvider;
 use Pollora\ThirdParty\WooCommerce\Infrastructure\Providers\WooCommerceServiceProvider;
 use Pollora\ThirdParty\WpRocket\WpRocketServiceProvider;
+use Pollora\VersionCheck\Infrastructure\Providers\VersionCheckServiceProvider;
 use Pollora\View\Infrastructure\Providers\TemplateHierarchyServiceProvider;
 use Pollora\View\ViewServiceProvider;
 use Pollora\WordPress\Config\ConstantServiceProvider;
@@ -130,6 +131,9 @@ class PolloraServiceProvider extends ServiceProvider
         // Hashing service provider
         $this->app->register(HashServiceProvider::class);
         $this->app->register(WordPressServiceProvider::class);
+
+        // Version check notifications
+        $this->app->register(VersionCheckServiceProvider::class);
     }
 
     /**

--- a/src/VersionCheck/Domain/Contracts/VersionCheckerInterface.php
+++ b/src/VersionCheck/Domain/Contracts/VersionCheckerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pollora\VersionCheck\Domain\Contracts;
+
+use Pollora\VersionCheck\Infrastructure\Services\PackagistVersionChecker;
+
+/**
+ * Contract for checking Pollora framework version information.
+ *
+ * Implementations are responsible for determining the currently installed
+ * version and fetching the latest available version from a remote source.
+ *
+ * @see PackagistVersionChecker
+ */
+interface VersionCheckerInterface
+{
+    /**
+     * Get the latest stable version available from the remote source.
+     *
+     * @return string|null The latest version string (e.g. "13.3.0"), or null if unavailable
+     */
+    public function getLatestVersion(): ?string;
+
+    /**
+     * Get the currently installed version of the Pollora framework.
+     *
+     * @return string|null The current version string (e.g. "13.3.0"), or null if undetermined
+     */
+    public function getCurrentVersion(): ?string;
+}

--- a/src/VersionCheck/Domain/Services/VersionComparator.php
+++ b/src/VersionCheck/Domain/Services/VersionComparator.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pollora\VersionCheck\Domain\Services;
+
+use Pollora\VersionCheck\Domain\Contracts\VersionCheckerInterface;
+
+/**
+ * Compares the installed Pollora version against the latest available version.
+ *
+ * This domain service encapsulates the version comparison logic and acts as
+ * the primary entry point for UI components (admin notice, Site Health) to
+ * determine whether an update is available.
+ *
+ * @see VersionCheckerInterface
+ */
+class VersionComparator
+{
+    public function __construct(
+        private readonly VersionCheckerInterface $checker
+    ) {}
+
+    /**
+     * Determine whether a newer version of Pollora is available.
+     *
+     * Returns false if either version cannot be determined, ensuring
+     * no false-positive update notifications are shown.
+     */
+    public function isUpdateAvailable(): bool
+    {
+        $current = $this->checker->getCurrentVersion();
+        $latest = $this->checker->getLatestVersion();
+
+        if ($current === null || $latest === null) {
+            return false;
+        }
+
+        return version_compare($latest, $current, '>');
+    }
+
+    /**
+     * Get the currently installed version.
+     *
+     * Delegates to the underlying VersionCheckerInterface implementation.
+     *
+     * @return string|null The current version string, or null if undetermined
+     */
+    public function getCurrentVersion(): ?string
+    {
+        return $this->checker->getCurrentVersion();
+    }
+
+    /**
+     * Get the latest available version.
+     *
+     * Delegates to the underlying VersionCheckerInterface implementation.
+     *
+     * @return string|null The latest version string, or null if unavailable
+     */
+    public function getLatestVersion(): ?string
+    {
+        return $this->checker->getLatestVersion();
+    }
+}

--- a/src/VersionCheck/Infrastructure/Providers/VersionCheckServiceProvider.php
+++ b/src/VersionCheck/Infrastructure/Providers/VersionCheckServiceProvider.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pollora\VersionCheck\Infrastructure\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Pollora\Hook\Domain\Contracts\Action;
+use Pollora\Hook\Domain\Contracts\Filter;
+use Pollora\VersionCheck\Domain\Contracts\VersionCheckerInterface;
+use Pollora\VersionCheck\Domain\Services\VersionComparator;
+use Pollora\VersionCheck\Infrastructure\Services\PackagistVersionChecker;
+use Pollora\VersionCheck\UI\Http\AdminNotice;
+use Pollora\VersionCheck\UI\Http\SiteHealthCheck;
+
+/**
+ * Service provider for the Pollora version check module.
+ *
+ * Registers version checking services in the container and hooks the
+ * admin notice and Site Health integration into WordPress when running
+ * in the admin context.
+ *
+ * Hooks registered:
+ * - `admin_notices`: Displays a dismissable update banner
+ * - `wp_ajax_pollora_dismiss_update_notice`: Handles notice dismissal via AJAX
+ * - `debug_information`: Adds Pollora version info to Site Health debug data
+ * - `site_status_tests`: Adds a version status test to Site Health
+ */
+class VersionCheckServiceProvider extends ServiceProvider
+{
+    /**
+     * Register version check services in the container.
+     *
+     * Binds the VersionCheckerInterface to the Packagist implementation
+     * and registers the VersionComparator as a singleton.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(VersionCheckerInterface::class, PackagistVersionChecker::class);
+        $this->app->singleton(VersionComparator::class);
+    }
+
+    /**
+     * Boot version check hooks into WordPress admin.
+     *
+     * Only registers hooks when running in the WordPress admin context
+     * to avoid unnecessary overhead on frontend requests.
+     *
+     * @param  Action  $action  WordPress action hook service
+     * @param  Filter  $filter  WordPress filter hook service
+     */
+    public function boot(Action $action, Filter $filter): void
+    {
+        if (! function_exists('is_admin') || ! is_admin()) {
+            return;
+        }
+
+        $action->add('admin_notices', [$this->app->make(AdminNotice::class), 'render']);
+        $action->add('wp_ajax_pollora_dismiss_update_notice', [$this->app->make(AdminNotice::class), 'dismiss']);
+
+        $filter->add('debug_information', [$this->app->make(SiteHealthCheck::class), 'addDebugInfo']);
+        $filter->add('site_status_tests', [$this->app->make(SiteHealthCheck::class), 'addTests']);
+    }
+}

--- a/src/VersionCheck/Infrastructure/Services/PackagistVersionChecker.php
+++ b/src/VersionCheck/Infrastructure/Services/PackagistVersionChecker.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pollora\VersionCheck\Infrastructure\Services;
+
+use Composer\InstalledVersions;
+use Pollora\VersionCheck\Domain\Contracts\VersionCheckerInterface;
+
+/**
+ * Checks Pollora version information using Packagist API and Composer runtime.
+ *
+ * The latest version is fetched from the Packagist API v2 endpoint and cached
+ * in a WordPress transient for 12 hours to avoid excessive API calls.
+ * The current version is read from Composer's installed packages metadata.
+ *
+ * Only stable versions are considered (dev, alpha, beta, and RC are skipped).
+ */
+class PackagistVersionChecker implements VersionCheckerInterface
+{
+    /** @var string Composer package name for the Pollora framework */
+    private const string PACKAGE_NAME = 'pollora/framework';
+
+    /** @var string Packagist API v2 endpoint for package metadata */
+    private const string PACKAGIST_URL = 'https://repo.packagist.org/p2/pollora/framework.json';
+
+    /** @var string WordPress transient key for caching the latest version */
+    private const string TRANSIENT_KEY = 'pollora_latest_version';
+
+    /** @var int Cache duration in seconds (12 hours) */
+    private const int CACHE_TTL = 43200;
+
+    /**
+     * {@inheritDoc}
+     *
+     * Checks the WordPress transient cache first. On cache miss, fetches
+     * from the Packagist API and stores the result for subsequent requests.
+     */
+    public function getLatestVersion(): ?string
+    {
+        $cached = get_transient(self::TRANSIENT_KEY);
+
+        if (is_string($cached) && $cached !== '') {
+            return $cached;
+        }
+
+        $version = $this->fetchLatestVersion();
+
+        if ($version !== null) {
+            set_transient(self::TRANSIENT_KEY, $version, self::CACHE_TTL);
+        }
+
+        return $version;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Uses Composer's InstalledVersions runtime API to read the version
+     * from the installed packages metadata. Strips the leading "v" prefix.
+     */
+    public function getCurrentVersion(): ?string
+    {
+        if (! InstalledVersions::isInstalled(self::PACKAGE_NAME)) {
+            return null;
+        }
+
+        $version = InstalledVersions::getPrettyVersion(self::PACKAGE_NAME);
+
+        if ($version === null) {
+            return null;
+        }
+
+        return ltrim($version, 'v');
+    }
+
+    /**
+     * Fetch the latest version from the Packagist API.
+     *
+     * Uses WordPress HTTP API (wp_remote_get) with a 5-second timeout.
+     * Returns null on any network or parsing error.
+     */
+    private function fetchLatestVersion(): ?string
+    {
+        $response = wp_remote_get(self::PACKAGIST_URL, [
+            'timeout' => 5,
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+
+        if (is_wp_error($response)) {
+            return null;
+        }
+
+        $body = wp_remote_retrieve_body($response);
+        $data = json_decode($body, true);
+
+        if (! is_array($data)) {
+            return null;
+        }
+
+        return $this->extractLatestStableVersion($data);
+    }
+
+    /**
+     * Extract the latest stable version from Packagist API response data.
+     *
+     * Iterates through the package releases (ordered newest-first by Packagist)
+     * and returns the first version that is not a dev, alpha, beta, or RC release.
+     *
+     * @param  array  $data  Decoded JSON response from Packagist API
+     * @return string|null The latest stable version string, or null if none found
+     */
+    private function extractLatestStableVersion(array $data): ?string
+    {
+        $packages = $data['packages'][self::PACKAGE_NAME] ?? [];
+
+        foreach ($packages as $release) {
+            $version = $release['version'] ?? '';
+
+            if (str_contains($version, 'dev')) {
+                continue;
+            }
+
+            if (str_contains($version, 'alpha')) {
+                continue;
+            }
+
+            if (str_contains($version, 'beta')) {
+                continue;
+            }
+
+            if (str_contains($version, 'RC')) {
+                continue;
+            }
+
+            return ltrim($version, 'v');
+        }
+
+        return null;
+    }
+}

--- a/src/VersionCheck/UI/Http/AdminNotice.php
+++ b/src/VersionCheck/UI/Http/AdminNotice.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pollora\VersionCheck\UI\Http;
+
+use Illuminate\Support\Facades\Request;
+use Pollora\VersionCheck\Domain\Services\VersionComparator;
+use Pollora\VersionCheck\Infrastructure\Providers\VersionCheckServiceProvider;
+
+/**
+ * Renders a dismissable WordPress admin notice when a Pollora update is available.
+ *
+ * The notice is displayed as a warning banner in the WordPress admin area.
+ * Users can dismiss it via the standard WordPress dismiss button, which triggers
+ * an AJAX request storing the dismissed version in user meta. The notice will
+ * reappear when a newer version becomes available.
+ *
+ * @see VersionCheckServiceProvider
+ */
+class AdminNotice
+{
+    /** @var string User meta key storing the version that was dismissed */
+    private const string DISMISS_META_KEY = 'pollora_dismissed_update_version';
+
+    /** @var string WordPress nonce action for dismiss AJAX request */
+    private const string NONCE_ACTION = 'pollora_dismiss_update';
+
+    public function __construct(
+        private readonly VersionComparator $comparator
+    ) {}
+
+    /**
+     * Render the update notice in the WordPress admin area.
+     *
+     * Outputs a warning notice with the available version, a link to the
+     * changelog, and inline JavaScript to handle dismissal via AJAX.
+     * Does nothing if no update is available or the notice was already dismissed.
+     */
+    public function render(): void
+    {
+        if (! $this->comparator->isUpdateAvailable()) {
+            return;
+        }
+
+        $latest = $this->comparator->getLatestVersion();
+
+        if ($this->isDismissed($latest)) {
+            return;
+        }
+
+        $current = $this->comparator->getCurrentVersion();
+        $nonce = wp_create_nonce(self::NONCE_ACTION);
+        $changelogUrl = 'https://github.com/Pollora/framework/releases/tag/v'.$latest;
+
+        printf(
+            '<div class="notice notice-warning is-dismissible pollora-update-notice" data-version="%s" data-nonce="%s">'
+            .'<p><strong>Pollora %s</strong> is available (you are using %s). '
+            .'<a href="%s" target="_blank" rel="noopener noreferrer">View changelog</a>.</p>'
+            .'</div>'
+            .'<script>jQuery(function($){'
+            .'$(document).on("click",".pollora-update-notice .notice-dismiss",function(){'
+            .'var $n=$(this).closest(".pollora-update-notice");'
+            .'$.post(ajaxurl,{action:"pollora_dismiss_update_notice",version:$n.data("version"),_wpnonce:$n.data("nonce")});'
+            .'});'
+            .'});</script>',
+            esc_attr($latest),
+            esc_attr($nonce),
+            esc_html($latest),
+            esc_html($current ?? 'unknown'),
+            esc_url($changelogUrl)
+        );
+    }
+
+    /**
+     * Handle the AJAX request to dismiss the update notice.
+     *
+     * Verifies the nonce, then stores the dismissed version in user meta
+     * so the notice is not shown again until a newer version is released.
+     * Called via the `wp_ajax_pollora_dismiss_update_notice` action.
+     */
+    public function dismiss(): void
+    {
+        check_ajax_referer(self::NONCE_ACTION);
+
+        $version = sanitize_text_field(Request::post('version') ?? '');
+
+        if ($version !== '') {
+            update_user_meta(get_current_user_id(), self::DISMISS_META_KEY, $version);
+        }
+
+        wp_die();
+    }
+
+    /**
+     * Check whether the user has dismissed the notice for the given version.
+     *
+     * @param  string|null  $version  The version to check against the dismissed version
+     * @return bool True if the notice was dismissed for this exact version
+     */
+    private function isDismissed(?string $version): bool
+    {
+        if ($version === null) {
+            return false;
+        }
+
+        $dismissed = get_user_meta(get_current_user_id(), self::DISMISS_META_KEY, true);
+
+        return $dismissed === $version;
+    }
+}

--- a/src/VersionCheck/UI/Http/SiteHealthCheck.php
+++ b/src/VersionCheck/UI/Http/SiteHealthCheck.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pollora\VersionCheck\UI\Http;
+
+use Pollora\VersionCheck\Domain\Services\VersionComparator;
+
+/**
+ * Integrates Pollora version information into WordPress Site Health.
+ *
+ * Provides two integration points:
+ * - **Debug Information** (`Tools > Site Health > Info`): Displays the installed
+ *   and latest Pollora version in a dedicated "Pollora" section.
+ * - **Status Tests** (`Tools > Site Health > Status`): Adds a test that reports
+ *   whether Pollora is up to date, with actionable links to the changelog.
+ *
+ * @see https://developer.wordpress.org/reference/hooks/debug_information/
+ * @see https://developer.wordpress.org/reference/hooks/site_status_tests/
+ */
+class SiteHealthCheck
+{
+    public function __construct(
+        private readonly VersionComparator $comparator
+    ) {}
+
+    /**
+     * Add a "Pollora" section to the Site Health debug information page.
+     *
+     * Displays the installed version, latest available version, and whether
+     * the framework is up to date.
+     *
+     * @param  array  $info  Existing debug information sections
+     * @return array Modified debug information with the Pollora section appended
+     */
+    public function addDebugInfo(array $info): array
+    {
+        $current = $this->comparator->getCurrentVersion() ?? 'Unknown';
+        $latest = $this->comparator->getLatestVersion() ?? 'Unable to check';
+
+        $info['pollora'] = [
+            'label' => 'Pollora',
+            'fields' => [
+                'version' => [
+                    'label' => 'Installed version',
+                    'value' => $current,
+                ],
+                'latest_version' => [
+                    'label' => 'Latest version',
+                    'value' => $latest,
+                ],
+                'up_to_date' => [
+                    'label' => 'Up to date',
+                    'value' => $this->comparator->isUpdateAvailable() ? 'No' : 'Yes',
+                ],
+            ],
+        ];
+
+        return $info;
+    }
+
+    /**
+     * Register the Pollora version check as a direct Site Health status test.
+     *
+     * The test appears under the "Status" tab and calls {@see testVersionStatus()}
+     * to determine whether the framework needs updating.
+     *
+     * @param  array  $tests  Existing status tests
+     * @return array Modified status tests with the Pollora check appended
+     */
+    public function addTests(array $tests): array
+    {
+        $tests['direct']['pollora_update'] = [
+            'label' => 'Pollora is up to date',
+            'test' => $this->testVersionStatus(...),
+        ];
+
+        return $tests;
+    }
+
+    /**
+     * Execute the version status test for Site Health.
+     *
+     * Returns one of three results:
+     * - **good** (blue badge): Pollora is up to date
+     * - **recommended** (orange badge): A newer version is available
+     * - **recommended** (orange badge): Version status could not be determined
+     *
+     * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, test: string, actions?: string} Test result
+     */
+    public function testVersionStatus(): array
+    {
+        $current = $this->comparator->getCurrentVersion();
+        $latest = $this->comparator->getLatestVersion();
+
+        if ($current === null || $latest === null) {
+            return [
+                'label' => 'Unable to determine Pollora version status',
+                'status' => 'recommended',
+                'badge' => [
+                    'label' => 'Pollora',
+                    'color' => 'orange',
+                ],
+                'description' => '<p>Could not determine the current or latest Pollora version. Check your internet connection.</p>',
+                'test' => 'pollora_update',
+            ];
+        }
+
+        if (! $this->comparator->isUpdateAvailable()) {
+            return [
+                'label' => 'Pollora is up to date',
+                'status' => 'good',
+                'badge' => [
+                    'label' => 'Pollora',
+                    'color' => 'blue',
+                ],
+                'description' => sprintf('<p>You are running Pollora %s, which is the latest version.</p>', $current),
+                'test' => 'pollora_update',
+            ];
+        }
+
+        return [
+            'label' => sprintf('Pollora %s is available', $latest),
+            'status' => 'recommended',
+            'badge' => [
+                'label' => 'Pollora',
+                'color' => 'orange',
+            ],
+            'description' => sprintf(
+                '<p>You are running Pollora %s. The latest version is %s. <a href="%s" target="_blank" rel="noopener noreferrer">View changelog</a>.</p>',
+                $current,
+                $latest,
+                'https://github.com/Pollora/framework/releases/tag/v'.$latest
+            ),
+            'actions' => sprintf(
+                '<p><a href="%s" target="_blank" rel="noopener noreferrer">Learn more about updating Pollora</a></p>',
+                'https://github.com/Pollora/framework/blob/main/CHANGELOG.md'
+            ),
+            'test' => 'pollora_update',
+        ];
+    }
+}

--- a/tests/Unit/VersionCheck/AdminNoticeTest.php
+++ b/tests/Unit/VersionCheck/AdminNoticeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Pollora\VersionCheck\Domain\Contracts\VersionCheckerInterface;
+use Pollora\VersionCheck\Domain\Services\VersionComparator;
+use Pollora\VersionCheck\UI\Http\AdminNotice;
+
+require_once dirname(__DIR__).'/helpers.php';
+
+beforeEach(function () {
+    setupWordPressMocks();
+});
+
+describe('AdminNotice', function () {
+    it('renders nothing when no update is available', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.3.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $notice = new AdminNotice(new VersionComparator($checker));
+
+        ob_start();
+        $notice->render();
+        $output = ob_get_clean();
+
+        expect($output)->toBeEmpty();
+    });
+
+    it('renders a warning notice when update is available', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.2.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        setWordPressFunction('get_current_user_id', fn () => 1);
+        setWordPressFunction('get_user_meta', fn () => '');
+        setWordPressFunction('wp_create_nonce', fn () => 'test-nonce');
+
+        $notice = new AdminNotice(new VersionComparator($checker));
+
+        ob_start();
+        $notice->render();
+        $output = ob_get_clean();
+
+        expect($output)->toContain('Pollora 13.3.0');
+        expect($output)->toContain('13.2.0');
+        expect($output)->toContain('notice-warning');
+        expect($output)->toContain('is-dismissible');
+        expect($output)->toContain('changelog');
+    });
+
+    it('renders nothing when notice is dismissed for current version', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.2.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        setWordPressFunction('get_current_user_id', fn () => 1);
+        setWordPressFunction('get_user_meta', fn () => '13.3.0');
+
+        $notice = new AdminNotice(new VersionComparator($checker));
+
+        ob_start();
+        $notice->render();
+        $output = ob_get_clean();
+
+        expect($output)->toBeEmpty();
+    });
+});

--- a/tests/Unit/VersionCheck/PackagistVersionCheckerTest.php
+++ b/tests/Unit/VersionCheck/PackagistVersionCheckerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+use Pollora\VersionCheck\Infrastructure\Services\PackagistVersionChecker;
+
+require_once dirname(__DIR__).'/helpers.php';
+
+beforeEach(function () {
+    setupWordPressMocks();
+});
+
+describe('PackagistVersionChecker', function () {
+    it('returns the currently installed version', function () {
+        $checker = new PackagistVersionChecker;
+        $version = $checker->getCurrentVersion();
+
+        expect($version)->not->toBeNull();
+        expect($version)->toBeString();
+    });
+
+    it('returns cached version from transient', function () {
+        setWordPressFunction('get_transient', fn () => '99.0.0');
+
+        $checker = new PackagistVersionChecker;
+
+        expect($checker->getLatestVersion())->toBe('99.0.0');
+    });
+
+    it('fetches from packagist when no cache and stores in transient', function () {
+        setWordPressFunction('get_transient', fn () => false);
+
+        $storedVersion = null;
+        setWordPressFunction('set_transient', function ($key, $value, $ttl) use (&$storedVersion) {
+            $storedVersion = $value;
+
+            return true;
+        });
+
+        setWordPressFunction('wp_remote_get', fn () => [
+            'body' => json_encode([
+                'packages' => [
+                    'pollora/framework' => [
+                        ['version' => 'v13.3.0'],
+                        ['version' => 'v13.2.0'],
+                    ],
+                ],
+            ]),
+            'response' => ['code' => 200],
+        ]);
+
+        setWordPressFunction('wp_remote_retrieve_body', fn ($response) => $response['body']);
+        setWordPressFunction('is_wp_error', fn () => false);
+
+        $checker = new PackagistVersionChecker;
+
+        expect($checker->getLatestVersion())->toBe('13.3.0');
+        expect($storedVersion)->toBe('13.3.0');
+    });
+
+    it('skips dev and pre-release versions', function () {
+        setWordPressFunction('get_transient', fn () => false);
+        setWordPressFunction('set_transient', fn () => true);
+
+        setWordPressFunction('wp_remote_get', fn () => [
+            'body' => json_encode([
+                'packages' => [
+                    'pollora/framework' => [
+                        ['version' => 'dev-main'],
+                        ['version' => 'v14.0.0-beta.1'],
+                        ['version' => 'v13.4.0-RC1'],
+                        ['version' => 'v13.3.0'],
+                    ],
+                ],
+            ]),
+            'response' => ['code' => 200],
+        ]);
+
+        setWordPressFunction('wp_remote_retrieve_body', fn ($response) => $response['body']);
+        setWordPressFunction('is_wp_error', fn () => false);
+
+        $checker = new PackagistVersionChecker;
+
+        expect($checker->getLatestVersion())->toBe('13.3.0');
+    });
+
+    it('returns null on API error', function () {
+        setWordPressFunction('get_transient', fn () => false);
+        setWordPressFunction('is_wp_error', fn () => true);
+        setWordPressFunction('wp_remote_get', fn () => new stdClass);
+
+        $checker = new PackagistVersionChecker;
+
+        expect($checker->getLatestVersion())->toBeNull();
+    });
+});

--- a/tests/Unit/VersionCheck/SiteHealthCheckTest.php
+++ b/tests/Unit/VersionCheck/SiteHealthCheckTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Pollora\VersionCheck\Domain\Contracts\VersionCheckerInterface;
+use Pollora\VersionCheck\Domain\Services\VersionComparator;
+use Pollora\VersionCheck\UI\Http\SiteHealthCheck;
+
+describe('SiteHealthCheck', function () {
+    it('adds Pollora section to debug information', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.3.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $health = new SiteHealthCheck(new VersionComparator($checker));
+        $info = $health->addDebugInfo([]);
+
+        expect($info)->toHaveKey('pollora');
+        expect($info['pollora']['label'])->toBe('Pollora');
+        expect($info['pollora']['fields']['version']['value'])->toBe('13.3.0');
+        expect($info['pollora']['fields']['latest_version']['value'])->toBe('13.3.0');
+        expect($info['pollora']['fields']['up_to_date']['value'])->toBe('Yes');
+    });
+
+    it('shows not up to date when update available', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.2.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $health = new SiteHealthCheck(new VersionComparator($checker));
+        $info = $health->addDebugInfo([]);
+
+        expect($info['pollora']['fields']['up_to_date']['value'])->toBe('No');
+    });
+
+    it('adds version test to site status tests', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+
+        $health = new SiteHealthCheck(new VersionComparator($checker));
+        $tests = $health->addTests([]);
+
+        expect($tests['direct'])->toHaveKey('pollora_update');
+        expect($tests['direct']['pollora_update']['test'])->toBeCallable();
+    });
+
+    it('returns good status when up to date', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.3.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $health = new SiteHealthCheck(new VersionComparator($checker));
+        $result = $health->testVersionStatus();
+
+        expect($result['status'])->toBe('good');
+        expect($result['badge']['color'])->toBe('blue');
+    });
+
+    it('returns recommended status when update available', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.2.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $health = new SiteHealthCheck(new VersionComparator($checker));
+        $result = $health->testVersionStatus();
+
+        expect($result['status'])->toBe('recommended');
+        expect($result['badge']['color'])->toBe('orange');
+        expect($result['label'])->toContain('13.3.0');
+    });
+
+    it('returns recommended status when version cannot be determined', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn(null);
+        $checker->shouldReceive('getLatestVersion')->andReturn(null);
+
+        $health = new SiteHealthCheck(new VersionComparator($checker));
+        $result = $health->testVersionStatus();
+
+        expect($result['status'])->toBe('recommended');
+    });
+});

--- a/tests/Unit/VersionCheck/VersionComparatorTest.php
+++ b/tests/Unit/VersionCheck/VersionComparatorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Pollora\VersionCheck\Domain\Contracts\VersionCheckerInterface;
+use Pollora\VersionCheck\Domain\Services\VersionComparator;
+
+describe('VersionComparator', function () {
+    it('detects update available when latest is newer', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.2.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->isUpdateAvailable())->toBeTrue();
+    });
+
+    it('reports no update when versions match', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.3.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->isUpdateAvailable())->toBeFalse();
+    });
+
+    it('reports no update when current is newer', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('14.0.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->isUpdateAvailable())->toBeFalse();
+    });
+
+    it('reports no update when current version is null', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn(null);
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->isUpdateAvailable())->toBeFalse();
+    });
+
+    it('reports no update when latest version is null', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.3.0');
+        $checker->shouldReceive('getLatestVersion')->andReturn(null);
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->isUpdateAvailable())->toBeFalse();
+    });
+
+    it('delegates getCurrentVersion to checker', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getCurrentVersion')->andReturn('13.2.0');
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->getCurrentVersion())->toBe('13.2.0');
+    });
+
+    it('delegates getLatestVersion to checker', function () {
+        $checker = Mockery::mock(VersionCheckerInterface::class);
+        $checker->shouldReceive('getLatestVersion')->andReturn('13.3.0');
+
+        $comparator = new VersionComparator($checker);
+
+        expect($comparator->getLatestVersion())->toBe('13.3.0');
+    });
+});

--- a/tests/Unit/helpers.php
+++ b/tests/Unit/helpers.php
@@ -1215,3 +1215,121 @@ if (! function_exists('delete_option')) {
         return isset(WP::$wpFunctions) ? WP::$wpFunctions->delete_option($option) : true;
     }
 }
+
+// WordPress transient functions
+if (! function_exists('get_transient')) {
+    function get_transient($transient)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->get_transient($transient) : false;
+    }
+}
+
+if (! function_exists('set_transient')) {
+    function set_transient($transient, $value, $expiration = 0)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->set_transient($transient, $value, $expiration) : true;
+    }
+}
+
+// WordPress HTTP functions
+if (! function_exists('wp_remote_get')) {
+    function wp_remote_get($url, $args = [])
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->wp_remote_get($url, $args) : new WP_Error;
+    }
+}
+
+if (! function_exists('wp_remote_retrieve_body')) {
+    function wp_remote_retrieve_body($response)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->wp_remote_retrieve_body($response) : '';
+    }
+}
+
+if (! function_exists('is_wp_error')) {
+    function is_wp_error($thing)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->is_wp_error($thing) : ($thing instanceof WP_Error);
+    }
+}
+
+// WordPress user functions
+if (! function_exists('get_current_user_id')) {
+    function get_current_user_id()
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->get_current_user_id() : 0;
+    }
+}
+
+if (! function_exists('get_user_meta')) {
+    function get_user_meta($user_id, $key = '', $single = false)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->get_user_meta($user_id, $key, $single) : '';
+    }
+}
+
+if (! function_exists('update_user_meta')) {
+    function update_user_meta($user_id, $meta_key, $meta_value, $prev_value = '')
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->update_user_meta($user_id, $meta_key, $meta_value, $prev_value) : true;
+    }
+}
+
+// WordPress security functions
+if (! function_exists('wp_create_nonce')) {
+    function wp_create_nonce($action = -1)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->wp_create_nonce($action) : 'test-nonce';
+    }
+}
+
+if (! function_exists('check_ajax_referer')) {
+    function check_ajax_referer($action = -1, $query_arg = false, $stop = true)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->check_ajax_referer($action, $query_arg, $stop) : true;
+    }
+}
+
+if (! function_exists('sanitize_text_field')) {
+    function sanitize_text_field($str)
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->sanitize_text_field($str) : trim(strip_tags($str));
+    }
+}
+
+if (! function_exists('wp_die')) {
+    function wp_die($message = '', $title = '', $args = [])
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->wp_die($message, $title, $args) : null;
+    }
+}
+
+// WordPress escaping functions
+if (! function_exists('esc_attr')) {
+    function esc_attr($text)
+    {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (! function_exists('esc_html')) {
+    function esc_html($text)
+    {
+        return htmlspecialchars((string) $text, ENT_QUOTES, 'UTF-8');
+    }
+}
+
+if (! function_exists('esc_url')) {
+    function esc_url($url)
+    {
+        return filter_var($url, FILTER_SANITIZE_URL) ?: '';
+    }
+}
+
+// WordPress i18n
+if (! function_exists('__')) {
+    function __($text, $domain = 'default')
+    {
+        return $text;
+    }
+}


### PR DESCRIPTION
## Summary
- Add dismissable admin notice when a newer Pollora version is available
- Add Site Health integration (debug info + status test)
- Uses Packagist API v2 with WordPress transient cache (12h)
- DDD architecture with full test coverage (21 tests)

Closes #162

## Test plan
- [ ] CI passes (Rector, Pint, PHPStan, Pest)
- [ ] Admin notice appears when installed version < latest
- [ ] Notice dismiss persists via user meta
- [ ] Site Health shows Pollora section in Info tab
- [ ] Site Health status test reports correct state