### PR TITLE
fix: respect DONOTCACHEPAGE constant in WordPressHeaders middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Pollora/framework/compare/v13.3.0...develop)
 
+### Fixed
+- `WordPressHeaders` middleware now respects the `DONOTCACHEPAGE` constant set by WooCommerce and compatible cache plugins, preventing public cache headers on cart, checkout, and account pages.
+
 ## [v13.3.0](https://github.com/Pollora/framework/compare/v13.2.0...v13.3.0) - 2026-04-22
 
 ### Added

--- a/src/Route/Infrastructure/Middleware/WordPressHeaders.php
+++ b/src/Route/Infrastructure/Middleware/WordPressHeaders.php
@@ -109,7 +109,19 @@ class WordPressHeaders
      */
     private function shouldSetPublicCache(): bool
     {
-        return $this->isWordPressFunctionAvailable('is_user_logged_in') && ! is_user_logged_in();
+        return $this->isWordPressFunctionAvailable('is_user_logged_in')
+            && ! is_user_logged_in()
+            && ! $this->isNocacheRequested();
+    }
+
+    /**
+     * Check if a cache plugin (e.g. WooCommerce) has requested no-cache via DONOTCACHEPAGE.
+     *
+     * @return bool True when caching must be suppressed
+     */
+    private function isNocacheRequested(): bool
+    {
+        return defined('DONOTCACHEPAGE') && (bool) DONOTCACHEPAGE;
     }
 
     /**

--- a/tests/Unit/Route/Infrastructure/Middleware/WordPressHeadersTest.php
+++ b/tests/Unit/Route/Infrastructure/Middleware/WordPressHeadersTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Pollora\Route\Infrastructure\Middleware\WordPressHeaders;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+describe('WordPressHeaders middleware', function (): void {
+    beforeEach(function (): void {
+        setupWordPressMocks();
+        $this->middleware = new WordPressHeaders;
+    });
+
+    it('throws TypeError when next handler returns a non-SymfonyResponse', function (): void {
+        $request = Request::create('/test');
+
+        expect(fn () => $this->middleware->handle(
+            $request,
+            fn ($req) => 'not-a-symfony-response'
+        ))->toThrow(TypeError::class);
+    });
+
+    it('sets public cache headers for a guest on a non-WordPress route', function (): void {
+        setWordPressFunction('is_user_logged_in', fn (): bool => false);
+
+        $route = Mockery::mock();
+        $route->shouldReceive('hasCondition')->andReturn(false);
+
+        $request = Request::create('/test');
+        $request->setRouteResolver(fn () => $route);
+
+        $innerResponse = new SymfonyResponse;
+        $response = $this->middleware->handle($request, fn ($req) => $innerResponse);
+
+        expect($response->headers->get('X-Powered-By'))->toBe('Pollora');
+        expect($response->headers->getCacheControlDirective('max-age'))->toBe('3600');
+        expect($response->headers->hasCacheControlDirective('must-revalidate'))->toBeTrue();
+        expect($response->headers->hasCacheControlDirective('public'))->toBeTrue();
+    });
+
+    it('does not set public cache headers for a logged-in user', function (): void {
+        setWordPressFunction('is_user_logged_in', fn (): bool => true);
+
+        $request = Request::create('/test');
+
+        $innerResponse = new SymfonyResponse;
+        $response = $this->middleware->handle($request, fn ($req) => $innerResponse);
+
+        expect($response->headers->getCacheControlDirective('max-age'))->toBeNull();
+    });
+
+    it('always adds the X-Powered-By Pollora header', function (): void {
+        setWordPressFunction('is_user_logged_in', fn (): bool => true);
+
+        $request = Request::create('/test');
+
+        $innerResponse = new SymfonyResponse;
+        $response = $this->middleware->handle($request, fn ($req) => $innerResponse);
+
+        expect($response->headers->get('X-Powered-By'))->toBe('Pollora');
+    });
+});

--- a/tests/Unit/helpers.php
+++ b/tests/Unit/helpers.php
@@ -178,6 +178,10 @@ function setupWordPressMocks(): void
         ->byDefault()
         ->andReturn(false);
 
+    WP::$wpFunctions->shouldReceive('is_user_logged_in')
+        ->andReturn(false)
+        ->byDefault();
+
     WP::$wpFunctions->shouldReceive('is_embed')
         ->byDefault()
         ->andReturn(false);
@@ -1217,6 +1221,13 @@ if (! function_exists('is_wp_error')) {
     function is_wp_error($thing)
     {
         return isset(WP::$wpFunctions) ? WP::$wpFunctions->is_wp_error($thing) : ($thing instanceof WP_Error);
+    }
+}
+
+if (! function_exists('is_user_logged_in')) {
+    function is_user_logged_in()
+    {
+        return isset(WP::$wpFunctions) ? WP::$wpFunctions->is_user_logged_in() : false;
     }
 }
 


### PR DESCRIPTION
WooCommerce sets DONOTCACHEPAGE=true on cart, checkout and account pages via WC_Cache_Helper::set_nocache_constants(). The middleware was ignoring this signal and serving Cache-Control: public on those sensitive pages, making them cacheable by Varnish/CDN.